### PR TITLE
Make some classes public

### DIFF
--- a/src/main/java/io/github/zlika/reproducible/ManifestStripper.java
+++ b/src/main/java/io/github/zlika/reproducible/ManifestStripper.java
@@ -26,7 +26,7 @@ import java.io.IOException;
  * - Build-Date / Build-Time
  * - Bnd-LastModified
  */
-final class ManifestStripper implements Stripper
+public final class ManifestStripper implements Stripper
 {
     @Override
     public void strip(File in, File out) throws IOException

--- a/src/main/java/io/github/zlika/reproducible/PomPropertiesStripper.java
+++ b/src/main/java/io/github/zlika/reproducible/PomPropertiesStripper.java
@@ -21,7 +21,7 @@ import java.io.IOException;
  * Strips non-reproducible data from Maven pom properties files.
  * This stripper removes all comment lines (as some of them can contain date/time).
  */
-final class PomPropertiesStripper implements Stripper
+public final class PomPropertiesStripper implements Stripper
 {
     @Override
     public void strip(File in, File out) throws IOException

--- a/src/main/java/io/github/zlika/reproducible/ZipStripper.java
+++ b/src/main/java/io/github/zlika/reproducible/ZipStripper.java
@@ -37,7 +37,7 @@ import org.apache.commons.compress.archivers.zip.ZipFile;
  * Strips non-reproducible data from a ZIP file.
  * It rebuilds the ZIP file with a predictable order for the zip entries and sets zip entry dates to a fixed value.
  */
-final class ZipStripper implements Stripper
+public final class ZipStripper implements Stripper
 {
     private final Map<String, Stripper> subFilters = new HashMap<>();
     


### PR DESCRIPTION
Hi! Could you consider making these couple of classes public, so they can be used from the reproducible-build sbt plugin I created by just wrapping the strippers from reproducible-build-maven-plugin?

Preliminary results are already quite promising (using it on a non-trivial Scala project, the Akka libraries, survived `reprotest --dont-vary time`).