### PR TITLE
Added special case for a manifest entry to reproduce a bug

### DIFF
--- a/src/main/java/io/github/zlika/reproducible/SortManifestFileStripper.java
+++ b/src/main/java/io/github/zlika/reproducible/SortManifestFileStripper.java
@@ -78,7 +78,7 @@ final class SortManifestFileStripper implements Stripper
         for (String line : lines)
         {
             // New section?
-            if (line.trim().isEmpty())
+            if (line.isEmpty())
             {
                 if (!currentSection.isEmpty())
                 {

--- a/src/test/resources/io/github/zlika/reproducible/MANIFEST-stripped.MF
+++ b/src/test/resources/io/github/zlika/reproducible/MANIFEST-stripped.MF
@@ -1,5 +1,7 @@
 Manifest-Version: 1.0
 Archiver-Version: Plexus Archiver
+Description: This is a dummy description with 2 trailing white spaces
+  
 Import-Package: org.eclipse.core.runtime;version="[3.4,4)";resolution:
  =optional,org.apache.commons.logging;resolution:=optional;version="[1
  .2,2)",org.eclipse.osgi.framework.console;version="[1.1,2)";resolutio

--- a/src/test/resources/io/github/zlika/reproducible/MANIFEST-stripped.MF
+++ b/src/test/resources/io/github/zlika/reproducible/MANIFEST-stripped.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Archiver-Version: Plexus Archiver
-Description: This is a dummy description with 2 trailing white spaces
+Description: This is a dummy description with 2 trailing white spaces 
   
 Import-Package: org.eclipse.core.runtime;version="[3.4,4)";resolution:
  =optional,org.apache.commons.logging;resolution:=optional;version="[1

--- a/src/test/resources/io/github/zlika/reproducible/MANIFEST.MF
+++ b/src/test/resources/io/github/zlika/reproducible/MANIFEST.MF
@@ -9,7 +9,8 @@ Import-Package: org.eclipse.core.runtime;version="[3.4,4)";resolution:
  n:=optional,org.eclipse.osgi.service.datalocation;version="[1.3,2)";r
  esolution:=optional,org.osgi.framework;version="[1.7,2)";resolution:=
  optional
-Description: This is a dummy description with 2 trailing white spaces  
+Description: This is a dummy description with 2 trailing white spaces 
+  
 
 Name: foo/bar/b
 Sealed: false

--- a/src/test/resources/io/github/zlika/reproducible/MANIFEST.MF
+++ b/src/test/resources/io/github/zlika/reproducible/MANIFEST.MF
@@ -9,6 +9,7 @@ Import-Package: org.eclipse.core.runtime;version="[3.4,4)";resolution:
  n:=optional,org.eclipse.osgi.service.datalocation;version="[1.3,2)";r
  esolution:=optional,org.osgi.framework;version="[1.7,2)";resolution:=
  optional
+Description: This is a dummy description with 2 trailing white spaces  
 
 Name: foo/bar/b
 Sealed: false


### PR DESCRIPTION
With this PR you can reproduce the issue described in https://github.com/Zlika/reproducible-build-maven-plugin/issues/15#issuecomment-370181336 .

The original manifest has a long line with 2 trailing spaces. Those spaces should be handled either 

* by properly continuing them on the next line
* by trimming them (might be break someone's use case)

This PR extends the test case expecting the former behaviour.