### PR TITLE
commons-compress: update to 1.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,8 @@
     <wagon-gitsite.version>0.3.1</wagon-gitsite.version>
     
     <!-- Dependency versions -->
-    <commons-compress.version>1.24.0</commons-compress.version>
+    <commons-compress.version>1.26.0</commons-compress.version>
+    <commons-codec.version>1.16.1</commons-codec.version>
     <junit.version>4.13.2</junit.version>
     <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
     <maven-plugin-api.version>3.6.0</maven-plugin-api.version>
@@ -135,6 +136,12 @@
           <artifactId>xz</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>${commons-codec.version}</version>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
This needs commons-codec as well, as this is an 'optional' dependency but we do use parts that use Codec.