### PR TITLE
Allow define lineseparator for strip-jaxb

### DIFF
--- a/src/main/java/io/github/zlika/reproducible/LineNumberStripper.java
+++ b/src/main/java/io/github/zlika/reproducible/LineNumberStripper.java
@@ -26,15 +26,19 @@ import java.util.List;
 /** Removes a given line in a text file based on the line number. */
 class LineNumberStripper implements Stripper
 {
-    private int lineNumber;
-    
+    private final int lineNumber;
+    private final LineSeparators lineSeparator;
+
     /**
      * Constructor.
+     *
      * @param lineNumber the line number to remove.
+     * @param lineEnding the line ending of file.
      */
-    public LineNumberStripper(int lineNumber)
+    public LineNumberStripper(int lineNumber, LineSeparators lineEnding)
     {
         this.lineNumber = lineNumber;
+        this.lineSeparator = lineEnding;
     }
     
     @Override
@@ -51,7 +55,7 @@ class LineNumberStripper implements Stripper
                     try
                     {
                         writer.write(lines.get(i));
-                        writer.write("\r\n");
+                        writer.write(lineSeparator.get());
                     }
                     catch (IOException e)
                     {

--- a/src/main/java/io/github/zlika/reproducible/LineSeparators.java
+++ b/src/main/java/io/github/zlika/reproducible/LineSeparators.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.zlika.reproducible;
+
+public enum LineSeparators
+{
+    /**
+     * windows line separator.
+     */
+    CRLF("\r\n"),
+    
+    /**
+     * unix line separator.
+     */
+    LF("\n"),
+    
+    /**
+     * mac line separator.
+     */
+    CR("\r"),
+    
+    /**
+     * system derived line separator.
+     */
+    SYSTEM(System.lineSeparator());
+  
+    private final String lineSeparator;
+    
+    LineSeparators(String lineSeparator)
+    {
+        this.lineSeparator = lineSeparator;
+    }
+    
+    public String get()
+    {
+        return lineSeparator;
+    }
+}

--- a/src/main/java/io/github/zlika/reproducible/StripJaxbMojo.java
+++ b/src/main/java/io/github/zlika/reproducible/StripJaxbMojo.java
@@ -113,6 +113,9 @@ public final class StripJaxbMojo extends AbstractMojo
     @Parameter(defaultValue = "", property = "reproducible.matchingCommentText")
     private String matchingCommentText;
 
+    @Parameter(defaultValue = "CRLF", property = "reproducible.lineSeparator")
+    private LineSeparators lineSeparator;
+
     @Override
     public void execute() throws MojoExecutionException
     {
@@ -135,8 +138,10 @@ public final class StripJaxbMojo extends AbstractMojo
         final Charset charset = Charset.forName(encoding);
         final JaxbObjectFactoryFixer objectFactoryFixer = new JaxbObjectFactoryFixer(getMatchingCommentTexts(),
                 charset);
-        final LineNumberStripper jaxbFileDateStripper = new LineNumberStripper(JAXB_FILE_TIMESTAMP_LINE_NUMBER);
-        final LineNumberStripper jaxbEpisodeDateStripper = new LineNumberStripper(JAXB_EPISODE_TIMESTAMP_LINE_NUMBER);
+        final LineNumberStripper jaxbFileDateStripper =
+            new LineNumberStripper(JAXB_FILE_TIMESTAMP_LINE_NUMBER, lineSeparator);
+        final LineNumberStripper jaxbEpisodeDateStripper =
+            new LineNumberStripper(JAXB_EPISODE_TIMESTAMP_LINE_NUMBER, lineSeparator);
         final File tmpFile = createTempFile();
         
         try


### PR DESCRIPTION
JAXB generates episode file with LF line endings. When run strip-jaxb goal file has changed ending to CRLF and this generates in our git "false diff"
It means that git commit failed and after the fail file is not detected as changed.

This Pull request allows define for this goal override custom line ending. 

Original behavior is preserved as default value is previous CRLF settings.